### PR TITLE
Document the importance of the `element-size` parameter

### DIFF
--- a/src/morphop.c
+++ b/src/morphop.c
@@ -54,7 +54,7 @@ static void query (void)
 		{ GIMP_PDB_IMAGE, "image", "Input image" },
 		{ GIMP_PDB_DRAWABLE, "drawable", "Input drawable" },
 		{ GIMP_PDB_INT32, "operator", "The morphological operator { EROSION (0), DILATION (1), OPENING (2), CLOSING (3), BOUNDEXTR(4), GRADIENT(5), HIT-OR-MISS(6), SKELETONIZATION(7), THICKENING(8), THINNING(9), WHITE-TOP-HAT(10), BLACK-TOP-HAT(11) }"},
-		{ GIMP_PDB_INT32, "element-size", "Initial size of the structuring element (fake parameter, it's always 7)" },
+		{ GIMP_PDB_INT32, "element-size", "The size of the next argument" },
 		{ GIMP_PDB_INT8ARRAY, "element",   ""
 			"The structuring element. Must be declared as an array representing a matrix, with size 7x7. "
 			"The first 7 cells represent the first row, and so on. To define the element, set each element[i] to 1, 0 or -1 in case of HIT-OR-MISS, THICKENING or THINNING" },


### PR DESCRIPTION
The current description claims that the `element-size` parameter is fake and unused. However, since the libgimp library requires that the length of an array must precede each array passed as a parameter to a plugin, the importance of the parameter is paramount. Failing to set the parameter to 7×7 when using the parameter from Script-Fu results in the plugin receiving only part of the input matrix. See:
- [Problem returning ARRAYs in plugins ](http://www.gimpusers.com/forums/gimp-developer/6165-problem-returning-arrays-in-plugins)
- [Passing an array to a GIMP module via Script-Fu](http://stackoverflow.com/questions/43099467/passing-an-array-to-a-gimp-module-via-script-fu)